### PR TITLE
Allow codesniffer version 2.x and 3.x, because 3.x is also compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Very simple PHPSpec code sniffing, based on PSR1 and PSR2",
     "keywords": ["PHPSpec", "code", "sniffer", "standards", "PHP_CodeSniffer"],
     "require": {
-        "squizlabs/php_codesniffer": "~2.0"
+        "squizlabs/php_codesniffer": "~2.0 || ~3.0"
     },
     "license": "GPL-3.0+",
     "authors": [


### PR DESCRIPTION
Composer throws an error when codesniffer 3.x is installed, but this package works fine with this version.